### PR TITLE
Make test executable name compatible with CTest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,11 +54,11 @@ jobs:
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       if: runner.os == 'Windows'
-      run: "bin/Release/test.exe"
+      run: "bin/Release/test_wdm.exe"
 
     - name: Test
       working-directory: ${{github.workspace}}/build
       # Execute tests defined by the CMake configuration.  
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
       if: runner.os != 'Windows'
-      run: ./bin/test
+      run: ./bin/test_wdm

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_executable(test test.cpp)
-target_link_libraries(test wdm)
+add_executable(test_wdm test.cpp)
+target_link_libraries(test_wdm wdm)


### PR DESCRIPTION
I need to enable CTest testing in `vinecopulib` to have tests discovered by VSCode and because it's generally a good idea when using CMake as a build system.

Unfortunately, I get the following error: 

```
[cmake] CMake Error at build/_deps/wdm-src/test/CMakeLists.txt:1 (add_executable):
[cmake]   The target name "test" is reserved when CTest testing is enabled.
```

This PR fix this.